### PR TITLE
Add pathToRoot to the generated docObject

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = tab
+trim_trailing_whitespace = false
+insert_final_newline = true

--- a/build/make_default_helpers.js
+++ b/build/make_default_helpers.js
@@ -57,6 +57,13 @@ module.exports = function(docMap, config, getCurrent, Handlebars){
 		return out;
 	};
 
+	var pathToRoot = function(name){
+		var toPath = path.join(config.dest, docsFilename(docMap[name] || name, config));
+		var root = config.cwd || config.dest;
+		var out = path.relative(path.dirname(toPath), root);
+		return out;
+	};
+
 	var helpers = {
 		// GENERIC HELPERS
 		/**
@@ -274,6 +281,7 @@ module.exports = function(docMap, config, getCurrent, Handlebars){
 			return (root.title || root.name)+ " - "+(this.title || this.name);
 		},
 		docObjectString: function(){
+			this.pathToRoot = pathToRoot(this.name);
 			return JSON.stringify(deepExtendWithoutBody(this)).replace("</script>", "<\\/script>");
 		},
 		pathToDest: function(){


### PR DESCRIPTION
This adds a pathToRoot property to the generated docObject that is
placed on the window. This will be used by the demo plugin (and possibly
		others) to know how to correcty insert an iframe from the root.

Closes #2