### PR TITLE
Add tag support to renderAsTemplate helper.

### DIFF
--- a/bit-docs.js
+++ b/bit-docs.js
@@ -1,5 +1,6 @@
 var generator = require("./html");
 var _ = require("lodash");
+var tags = require("./tags/tags");
 
 var mergeOnto = function(prop, dest, source){
     if(source[prop]) {
@@ -8,7 +9,9 @@ var mergeOnto = function(prop, dest, source){
 };
 
 module.exports = function(bitDocs){
-    bitDocs.register("generator", generator );
+    bitDocs.register("generator", generator);
+
+	bitDocs.register("tags", tags);
 
     bitDocs.handle("html", function(siteConfig, htmlConfig) {
         if(!siteConfig.html) {

--- a/build/make_default_helpers.js
+++ b/build/make_default_helpers.js
@@ -262,12 +262,12 @@ module.exports = function(docMap, config, getCurrent, Handlebars){
 		makeHtml: function(content){
 			return stmd_to_html(content);
 		},
-		renderAsTemplate: function(content){
-			if(config.templateRender !== true && getCurrent().templateRender !== true) {
-				return content;
-			} else {
+		renderAsTemplate: function(content) {
+			if(getCurrent().templaterender || config.templateRender || getCurrent().templateRender) {
 				var renderer = Handlebars.compile(content.toString());
 				return renderer(docMap);
+			} else {
+				return content;
 			}
 		},
 		/**

--- a/build/make_default_helpers.js
+++ b/build/make_default_helpers.js
@@ -263,10 +263,28 @@ module.exports = function(docMap, config, getCurrent, Handlebars){
 			return stmd_to_html(content);
 		},
 		renderAsTemplate: function(content) {
-			if(getCurrent().templaterender || config.templateRender || getCurrent().templateRender) {
-				var renderer = Handlebars.compile(content.toString());
+			var templateRender = config.templateRender || getCurrent().templateRender,
+				renderer;
+
+			if (templateRender === true) {
+				// Render {{}} if templateRender tag/option is true
+				renderer = Handlebars.compile(content.toString());
 				return renderer(docMap);
+			} else if (templateRender && templateRender.length === 2) {
+				// Render custom delimiters if supplied by templateRender
+				var open = new RegExp(templateRender[0], 'g'),
+					close = new RegExp(templateRender[1], 'g'),
+					toRender = content
+						.replace(/{{/g, '\\{\\{')
+						.replace(/}}/g, '\\}\\}')
+						.replace(open, '{{')
+						.replace(close, '}}');
+				renderer = Handlebars.compile(toRender);
+				return renderer(docMap)
+					.replace('\\{\\{', '{{')
+					.replace('\\}\\}', '}}');
 			} else {
+				// Otherwise, just return the content
 				return content;
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "mocha": ">= 1.18.0",
-    "rimraf": "2.1"
+    "rimraf": "2.1",
+	"bit-docs-process-tags": "0.0.5"
   }
 }

--- a/tags/tags.js
+++ b/tags/tags.js
@@ -1,0 +1,5 @@
+var templateRender = require('./template_render');
+
+module.exports = {
+	templaterender: templateRender
+};

--- a/tags/template_render.js
+++ b/tags/template_render.js
@@ -1,0 +1,15 @@
+module.exports = {
+    add: function(line, curData, scope, objects, currentWrite) {
+		var args = line.replace(/@templaterender/i, "").trim().split(' ').map(function(x) {
+			return x.trim();
+		});
+
+		if (!args[0] || args[0] === "true") {
+			curData.templateRender = true;
+		} else if (args.length === 2) {
+			curData.templateRender = args;
+		} else {
+			throw new Error('Invalid arguments for @templateRender: ', args);
+		}
+    }
+};

--- a/tags/template_render_test.js
+++ b/tags/template_render_test.js
@@ -1,0 +1,59 @@
+var processTags = require("bit-docs-process-tags");
+var render = require("./template_render");
+var assert = require("assert");
+
+describe("templateRender", function() {
+    it("adds templateRender without args", function() {
+        var body = generateProcessBody('');
+        processTags(body, function(newDoc, newScope) {
+            assert.ok(newDoc.templateRender === true);
+		});
+	});
+
+    it("adds templateRender with true", function() {
+        var body = generateProcessBody('true');
+		processTags(body, function(newDoc, newScope) {
+            assert.ok(newDoc.templateRender === true);
+		});
+	});
+
+    it("adds templateRender with delimiters and trimming", function() {
+        var body = generateProcessBody('     <% %>  ');
+		processTags(body, function(newDoc, newScope) {
+            assert.ok(newDoc.templateRender.length === 2);
+            assert.ok(newDoc.templateRender[0] === '<%');
+            assert.ok(newDoc.templateRender[1] === '%>');
+		});
+	});
+
+    it("throws error with malformed args", function() {
+        var processFunc = function() {
+            var body = generateProcessBody('<%%>');
+            processTags(body, function(newDoc, newScope) {});
+        };
+		assert.throws(processFunc);
+	});
+});
+
+function generateProcessBody(str) {
+    return {
+        comment: "@constructor\n@templateRender "+str,
+        scope: {},
+        docMap: {},
+        docObject: {
+            src: {
+                path: './'
+            }
+        },
+        tags: {
+            templaterender: render,
+            constructor: {
+                add : function() {
+                    this.name = "constructed";
+                    this.type = "constructor";
+                    return ["scope", this];
+                }
+            }
+        }
+    };
+}


### PR DESCRIPTION
Related to https://github.com/canjs/bit-docs-html-canjs/issues/59

tag keys will be converted to lowercase and values to strings before they are appended to current docObject