### PR TITLE
Add support to beautify html through js-beautify

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "escape-html": "^1.0.3",
     "fs-extra": "0.30.0",
     "handlebars": "1.X",
+    "js-beautify": "^1.6.8",
     "lodash": "~4.13.1",
     "md5": "2.1.0",
     "steal-tools": "0.16.X",

--- a/write/beautify_html.js
+++ b/write/beautify_html.js
@@ -1,0 +1,41 @@
+var _ = require("lodash");
+
+/**
+ * Returns js-beautify options object
+ *
+ * @param {{}} siteConfig The site configuration object
+ * @returns {{}} The js-beautify options object
+ *
+ * Options can be provided through the `beautifyHtml` object, if no
+ * options were provided some defaults are set.
+ */
+function getOptions(siteConfig) {
+	var opts = _.isObject(siteConfig.beautifyHtml) ?
+		siteConfig.beautifyHtml : {};
+
+	return _.defaults(opts, {
+		"indent_size": 2,
+		"max_preserve_newlines": 1,
+		"indent_scripts": "keep"
+	});
+}
+
+/**
+ * Beautifies html through js-beautify
+ *
+ * @param {string} rendered The rendered html string
+ * @param {{}} The site configuration object
+ */
+module.exports = function(rendered, siteConfig) {
+	var beautify = siteConfig.beautifyHtml === true ||
+		_.isObject(siteConfig.beautifyHtml);
+
+	if (beautify) {
+		var beautifier = require("js-beautify").html;
+
+		return beautifier(rendered, getOptions(siteConfig));
+	}
+	else {
+		return rendered;
+	}
+};


### PR DESCRIPTION
@justinbmeyer before I write any tests, wanted to run the idea by you.... 

```
generate(docMap, {
	html: {
		templates: "...",
		dependencies: {}
	},
	beautifyHtml: true,
	dest: "....",
	parent: "..."
});
```

With this change you could run the rendered html through js-beautify, you could either set the flag to `true` or pass an [options object](https://github.com/beautify-web/js-beautify#css--html).

Not a game-changer feature, but I thought it was cool to write out some nice looking html :)  
