### PR TITLE
Add support for file: syntax

### DIFF
--- a/build/static_dist.js
+++ b/build/static_dist.js
@@ -118,14 +118,7 @@ function addPackages(siteConfig, buildFolder) {
 				var possibleFilePath = siteConfig.dependencies[depName];
 
 				if (_.startsWith(possibleFilePath,'file:')) {
-					try {
-						var absDir = path.resolve(possibleFilePath.substr(5));
-						if(fs.statSync(absDir).isDirectory()) {
-							filePathedDeps[depName] = absDir;
-						}
-					} catch(err) {
-						// skip bad path
-					}
+					filePathedDeps[depName] = possibleFilePath;
 				}
 			}
 

--- a/build/static_dist.js
+++ b/build/static_dist.js
@@ -117,7 +117,7 @@ function addPackages(siteConfig, buildFolder) {
 			for(var depName in siteConfig.html.dependencies) {
 				var possibleFilePath = siteConfig.dependencies[depName];
 
-				if (_.startsWith(possibleFilePath,'file:')) {
+				if (possibleFilePath.startsWith('file:')) {
 					filePathedDeps[depName] = possibleFilePath;
 				}
 			}


### PR DESCRIPTION
Some commits of this PR depend on https://github.com/bit-docs/bit-docs/pull/26 being merged.

Alternative is to use `__dirname` in the plugins' `bit-docs.js`: https://github.com/bit-docs/bit-docs/issues/25

---

Useful if you want to have `bit-docs` use _local_ copies of plugins:

```json
  "bit-docs": {
    "dependencies": {
      "bit-docs-dev": "bit-docs/bit-docs-dev",
      "bit-docs-generate-html": "file:docs/modules/bit-docs-generate-html",
      "bit-docs-glob-finder": "bit-docs/bit-docs-glob-finder",
      "bit-docs-html-toc": "bit-docs/bit-docs-html-toc",
      "bit-docs-js": "bit-docs/bit-docs-js#remove-depend",
      "bit-docs-prettify": "file:docs/modules/bit-docs-prettify",
      "bit-docs-html-highlight-line": "bit-docs/bit-docs-html-highlight-line",
      "bit-docs-process-mustache": "bit-docs/bit-docs-process-mustache",
      "bit-docs-tag-demo": "bit-docs/bit-docs-tag-demo",
      "bit-docs-tag-sourceref": "bit-docs/bit-docs-tag-sourceref"
    },
```

Notice that the `file:` dependencies will not pull from GitHub like the others, but now will instead use the local copy thru and thru. In this case, items in `docs/modules` are git submodules.

---

The changes in this PR are necessary specifically for working with local `file:` plugins that register themselves to the `html` hook (a hook that is handled by `bit-docs-generate-html`). 

Such a plugins are:

- https://github.com/bit-docs/bit-docs-prettify
  - https://github.com/bit-docs/bit-docs-prettify/blob/master/bit-docs.js#L16
- https://github.com/bit-docs/bit-docs-html-highlight-line
  - https://github.com/bit-docs/bit-docs-html-highlight-line/blob/master/bit-docs.js#L19

Without this PR and when using `file:` to include them, any changes to files such as:

- https://github.com/bit-docs/bit-docs-html-highlight-line/blob/master/package.json#L5
  - https://github.com/bit-docs/bit-docs-html-highlight-line/blob/master/highlight-line.js
- https://github.com/bit-docs/bit-docs-prettify/blob/master/package.json#L5
  - https://github.com/bit-docs/bit-docs-prettify/blob/master/prettify.js#L2
  - https://github.com/bit-docs/bit-docs-prettify/blob/master/prettify.less

Won't come through, because currently `bit-docs-generate-html` will download from remote npm.