### PR TITLE
displays the path to the source file or displays "unknown" when current.src is undefined

### DIFF
--- a/build/make_default_helpers.js
+++ b/build/make_default_helpers.js
@@ -226,7 +226,7 @@ module.exports = function(docMap, config, getCurrent, Handlebars){
 			return "<!--####################################################################\n" +
 						 "\tTHIS IS A GENERATED FILE -- ANY CHANGES MADE WILL BE OVERWRITTEN\n\n" +
 						 '\tINSTEAD CHANGE:\n' +
-						 "\tsource: " + current.src +
+						 "\tsource: " + (current.src ? current.src.path : 'unknown') +
 						 (current.type ? '\n\t@' + current.type + " " + current.name : '') +
 						 "\n######################################################################## -->";
 		},


### PR DESCRIPTION
I noticed there are 148 cases within the canjs docs where current.src is undefined.

such as `doc/Component.html` and `doc/can.view.html`

in these cases, this PR opts to display

`source: unknown`